### PR TITLE
(#1694605) Backports/fixes for issues found by LGTM

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -7,3 +7,10 @@ extraction:
                       --disable-gtk-doc --disable-manpages --disable-gtk-doc-html
                       --enable-compat-libs --disable-sysusers --disable-ldconfig
                       --enable-lz4 --disable-microhttpd
+path_classifiers:
+  # Any files which have a tag attached are filtered out from results & stats
+  ignored:
+    # Skip files dropped in upstream
+    - src/bootchart/
+    - src/gudev/
+    - src/libsystemd/sd-bus/bus-bloom.c

--- a/src/analyze/analyze.c
+++ b/src/analyze/analyze.c
@@ -788,14 +788,11 @@ static int list_dependencies_one(sd_bus *bus, const char *name, unsigned int lev
                 if (times
                     && times->activated
                     && times->activated <= boot->finish_time
-                    && (times->activated >= service_longest
-                        || service_longest == 0)) {
+                    && times->activated >= service_longest)
                         service_longest = times->activated;
-                        break;
-                }
         }
 
-        if (service_longest == 0 )
+        if (service_longest == 0)
                 return r;
 
         STRV_FOREACH(c, deps) {

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -2806,9 +2806,7 @@ int manager_reload(Manager *m) {
         lookup_paths_free(&m->lookup_paths);
 
         /* Find new unit paths */
-        q = manager_run_generators(m);
-        if (q < 0 && r >= 0)
-                r = q;
+        r = manager_run_generators(m);
 
         q = lookup_paths_init(
                         &m->lookup_paths, m->running_as, true,

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -2035,7 +2035,7 @@ static int unit_watch_pids_in_path(Unit *u, const char *path) {
                 if (r < 0 && ret >= 0)
                         ret = r;
 
-        } else if (ret >= 0)
+        } else
                 ret = r;
 
         r = cg_enumerate_subgroups(SYSTEMD_CGROUP_CONTROLLER, path, &d);

--- a/src/import/import-common.c
+++ b/src/import/import-common.c
@@ -455,8 +455,7 @@ int import_verify(
         }
 
 finish:
-        if (sig_file >= 0)
-                unlink(sig_file_path);
+        (void) unlink(sig_file_path);
 
         if (gpg_home_created)
                 rm_rf_dangerous(gpg_home, false, true, false);

--- a/src/journal-remote/browse.html
+++ b/src/journal-remote/browse.html
@@ -236,10 +236,12 @@
 
                 function entriesLoad(range) {
 
-                        if (range == null)
-                                range = localStorage["cursor"] + ":0";
-                        if (range == null)
-                                range = "";
+                        if (range == null) {
+                                if (localStorage["cursor"] != null && localStorage["cursor"] != "")
+                                        range = localStorage["cursor"] + ":0";
+                                else
+                                        range = "";
+                        }
 
                         var url = "/entries";
 

--- a/src/journal-remote/browse.html
+++ b/src/journal-remote/browse.html
@@ -304,7 +304,6 @@
                         var buf = '';
 
                         for (i in l) {
-
                                 if (l[i] == '')
                                         continue;
 
@@ -322,6 +321,7 @@
                                 else
                                         priority = 6;
 
+                                var clazz;
                                 if (priority <= 3)
                                         clazz = "message-error";
                                 else if (priority <= 5)
@@ -388,7 +388,7 @@
                         var d = JSON.parse(event.currentTarget.responseText);
 
                         document.getElementById("diventry").style.display = "block";
-                        entry = document.getElementById("tableentry");
+                        var entry = document.getElementById("tableentry");
 
                         var buf = "";
                         for (var key in d){
@@ -455,7 +455,7 @@
                                 (event.currentTarget.status != 200 && event.currentTarget.status != 0))
                                 return;
 
-                        f = document.getElementById("filter");
+                        var f = document.getElementById("filter");
 
                         var l = event.currentTarget.responseText.split('\n');
                         var buf = '<option>No filter</option>';
@@ -511,11 +511,12 @@
                 }
 
                 function initFilter() {
-                        f = document.getElementById("filter");
+                        var f = document.getElementById("filter");
 
                         var buf = '<option>No filter</option>';
 
                         var filter = localStorage["filter"];
+                        var j;
                         if (filter != null && filter != "") {
                                 buf += '<option value="' + escape(filter) + '">' + escapeHTML(filter) + '</option>';
                                 j = 1;
@@ -529,7 +530,7 @@
                 function installHandlers() {
                         document.onkeyup = onKeyUp;
 
-                        logs = document.getElementById("divlogs");
+                        var logs = document.getElementById("divlogs");
                         logs.addEventListener("mousewheel", onMouseWheel, false);
                         logs.addEventListener("DOMMouseScroll", onMouseWheel, false);
                 }

--- a/src/journal-remote/journal-upload-journal.c
+++ b/src/journal-remote/journal-upload-journal.c
@@ -30,7 +30,8 @@ static ssize_t write_entry(char *buf, size_t size, Uploader *u) {
 
                         r = snprintf(buf + pos, size - pos,
                                      "__CURSOR=%s\n", u->current_cursor);
-                        if (pos + r > size)
+                        assert(r >= 0);
+                        if ((size_t) r > size - pos)
                                 /* not enough space */
                                 return pos;
 
@@ -54,7 +55,8 @@ static ssize_t write_entry(char *buf, size_t size, Uploader *u) {
 
                         r = snprintf(buf + pos, size - pos,
                                      "__REALTIME_TIMESTAMP="USEC_FMT"\n", realtime);
-                        if (r + pos > size)
+                        assert(r >= 0);
+                        if ((size_t) r > size - pos)
                                 /* not enough space */
                                 return pos;
 
@@ -79,7 +81,8 @@ static ssize_t write_entry(char *buf, size_t size, Uploader *u) {
 
                         r = snprintf(buf + pos, size - pos,
                                      "__MONOTONIC_TIMESTAMP="USEC_FMT"\n", monotonic);
-                        if (r + pos > size)
+                        assert(r >= 0);
+                        if ((size_t) r > size - pos)
                                 /* not enough space */
                                 return pos;
 
@@ -104,7 +107,8 @@ static ssize_t write_entry(char *buf, size_t size, Uploader *u) {
 
                         r = snprintf(buf + pos, size - pos,
                                      "_BOOT_ID=%s\n", sd_id128_to_string(boot_id, sid));
-                        if (r + pos > size)
+                        assert(r >= 0);
+                        if ((size_t) r > size - pos)
                                 /* not enough space */
                                 return pos;
 

--- a/src/journal/journal-verify.c
+++ b/src/journal/journal-verify.c
@@ -70,10 +70,11 @@ static void draw_progress(uint64_t p, usec_t *last_usec) {
 }
 
 static uint64_t scale_progress(uint64_t scale, uint64_t p, uint64_t m) {
+        /* Calculates scale * p / m, but handles m == 0 safely, and saturates.
+         * Currently all callers use m >= 1, but we keep the check to be defensive.
+         */
 
-        /* Calculates scale * p / m, but handles m == 0 safely, and saturates */
-
-        if (p >= m || m == 0)
+        if (p >= m || m == 0) // lgtm[cpp/constant-comparison]
                 return scale;
 
         return scale * p / m;

--- a/src/journal/journald-server.c
+++ b/src/journal/journald-server.c
@@ -345,7 +345,7 @@ static int system_journal_open(Server *s, bool flush_requested) {
                 if (r >= 0) {
                         server_fix_perms(s, s->system_journal, 0);
                         available_space(s, true);
-                } else if (r < 0) {
+                } else {
                         if (r != -ENOENT && r != -EROFS)
                                 log_warning_errno(r, "Failed to open system journal: %m");
 

--- a/src/libsystemd-network/sd-lldp.c
+++ b/src/libsystemd-network/sd-lldp.c
@@ -136,8 +136,6 @@ static int lldp_receive_frame(sd_lldp *lldp, tlv_packet *tlv) {
 
         lldp->statistics.stats_frames_in_total ++;
 
-        return 0;
-
  out:
         if (r < 0)
                 log_lldp("Receive frame failed: %s", strerror(-r));

--- a/src/libsystemd/sd-bus/bus-internal.h
+++ b/src/libsystemd/sd-bus/bus-internal.h
@@ -378,7 +378,7 @@ char *bus_address_escape(const char *v);
 
 #define OBJECT_PATH_FOREACH_PREFIX(prefix, path)                        \
         for (char *_slash = ({ strcpy((prefix), (path)); streq((prefix), "/") ? NULL : strrchr((prefix), '/'); }) ; \
-             _slash && !(_slash[(_slash) == (prefix)] = 0);             \
+             _slash && ((_slash[(_slash) == (prefix)] = 0), true);       \
              _slash = streq((prefix), "/") ? NULL : strrchr((prefix), '/'))
 
 /* If we are invoking callbacks of a bus object, ensure unreffing the

--- a/src/libsystemd/sd-bus/bus-introspect.c
+++ b/src/libsystemd/sd-bus/bus-introspect.c
@@ -74,7 +74,7 @@ int introspect_write_child_nodes(struct introspect *i, Set *s, const char *prefi
         return 0;
 }
 
-static void introspect_write_flags(struct introspect *i, int type, int flags) {
+static void introspect_write_flags(struct introspect *i, int type, uint64_t flags) {
         if (flags & SD_BUS_VTABLE_DEPRECATED)
                 fputs("   <annotation name=\"org.freedesktop.DBus.Deprecated\" value=\"true\"/>\n", i->f);
 

--- a/src/libsystemd/sd-event/sd-event.c
+++ b/src/libsystemd/sd-event/sd-event.c
@@ -68,7 +68,7 @@ struct sd_event_source {
         char *description;
 
         EventSourceType type:5;
-        int enabled:3;
+        signed int enabled:3;
         bool pending:1;
         bool dispatching:1;
         bool floating:1;

--- a/src/machine/machinectl.c
+++ b/src/machine/machinectl.c
@@ -1086,7 +1086,7 @@ static int copy_files(int argc, char *argv[], void *userdata) {
                 return r;
 
         hostfd = open(host_dirname, O_CLOEXEC|O_RDONLY|O_NOCTTY|O_DIRECTORY);
-        if (r < 0)
+        if (hostfd < 0)
                 return log_error_errno(errno, "Failed to open source directory: %m");
 
         child = fork();

--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -1482,9 +1482,9 @@ static int install_context_apply(
                 if (q < 0)
                         return q;
 
-                r = install_info_traverse(scope, c, root_dir, paths, i, flags, NULL);
-                if (r < 0)
-                        return r;
+                q = install_info_traverse(scope, c, root_dir, paths, i, flags, NULL);
+                if (q < 0)
+                        return q;
 
                 if (i->type != UNIT_FILE_TYPE_REGULAR)
                         continue;

--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -4651,7 +4651,7 @@ static int cat(sd_bus *bus, char **args) {
         _cleanup_strv_free_ char **names = NULL;
         char **name;
         bool first = true, avoid_bus_cache;
-        int r = 0;
+        int r;
 
         assert(args);
 
@@ -4701,7 +4701,7 @@ static int cat(sd_bus *bus, char **args) {
                 }
         }
 
-        return r < 0 ? r : 0;
+        return 0;
 }
 
 static int set_property(sd_bus *bus, char **args) {

--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -4309,7 +4309,7 @@ static int show_one(
                                 return log_oom();
 
                         r = set_put(found_properties, name);
-                        if (r < 0 && r != EEXIST)
+                        if (r < 0)
                                 return log_oom();
 
                         r = print_property(name, reply, contents);

--- a/src/sysv-generator/sysv-generator.c
+++ b/src/sysv-generator/sysv-generator.c
@@ -568,7 +568,7 @@ static int load_sysv(SysvStub *s) {
                                                 }
                                         }
 
-                                        if (r < 0)
+                                        if (r < 0) // lgtm[cpp/constant-comparison]
                                                 log_unit_error(s->name,
                                                                "[%s:%u] Failed to add dependency on %s, ignoring: %s",
                                                                s->path, line, m, strerror(-r));

--- a/src/timedate/timedated.c
+++ b/src/timedate/timedated.c
@@ -542,9 +542,9 @@ static int method_set_local_rtc(sd_bus *bus, sd_bus_message *m, void *userdata, 
                  * initialize the timezone fields of
                  * struct tm. */
                 if (c->local_rtc)
-                        tm = *localtime(&ts.tv_sec);
+                        localtime_r(&ts.tv_sec, &tm);
                 else
-                        tm = *gmtime(&ts.tv_sec);
+                        gmtime_r(&ts.tv_sec, &tm);
 
                 /* Override the main fields of
                  * struct tm, but not the timezone
@@ -562,15 +562,15 @@ static int method_set_local_rtc(sd_bus *bus, sd_bus_message *m, void *userdata, 
                 }
 
         } else {
-                struct tm *tm;
+                struct tm tm;
 
                 /* Sync RTC from system clock */
                 if (c->local_rtc)
-                        tm = localtime(&ts.tv_sec);
+                        localtime_r(&ts.tv_sec, &tm);
                 else
-                        tm = gmtime(&ts.tv_sec);
+                        gmtime_r(&ts.tv_sec, &tm);
 
-                clock_set_hwclock(tm);
+                clock_set_hwclock(&tm);
         }
 
         log_info("RTC configured to %s time.", c->local_rtc ? "local" : "UTC");
@@ -585,7 +585,7 @@ static int method_set_time(sd_bus *bus, sd_bus_message *m, void *userdata, sd_bu
         Context *c = userdata;
         int64_t utc;
         struct timespec ts;
-        struct tm* tm;
+        struct tm tm;
         int r;
 
         assert(bus);
@@ -633,10 +633,10 @@ static int method_set_time(sd_bus *bus, sd_bus_message *m, void *userdata, sd_bu
 
         /* Sync down to RTC */
         if (c->local_rtc)
-                tm = localtime(&ts.tv_sec);
+                localtime_r(&ts.tv_sec, &tm);
         else
-                tm = gmtime(&ts.tv_sec);
-        clock_set_hwclock(tm);
+                gmtime_r(&ts.tv_sec, &tm);
+        clock_set_hwclock(&tm);
 
         log_struct(LOG_INFO,
                    LOG_MESSAGE_ID(SD_MESSAGE_TIME_CHANGE),

--- a/src/tty-ask-password-agent/tty-ask-password-agent.c
+++ b/src/tty-ask-password-agent/tty-ask-password-agent.c
@@ -150,7 +150,7 @@ static int ask_password_plymouth(
 
                 p += k;
 
-                if (p < 1)
+                if (p < 1) // lgtm[cpp/constant-comparison]
                         continue;
 
                 if (buffer[0] == 5) {


### PR DESCRIPTION
Moved over from https://github.com/lnykryn/systemd-rhel/pull/311

This PR attempts to fix errors & warnings found by LGTM. Recommendations are currently ignored, as it would make this PR unnecessarily big.

**Note:** some of these patches are not even in upstream (mostly because the particular code was completely rewritten in upstream).

Unresolved errors/warnings:
 - **[error]** `src/shared/pager.c` [[link]](https://lgtm.com/projects/g/lnykryn/systemd-rhel/snapshot/fe7b6b6c19424e12d6fb721e94422a5ff28b7125/files/src/shared/pager.c?sort=name&dir=ASC&mode=heatmap#x437173520f29364c:1) - pager-related stuff has been significantly refactored in upstream, needs further investigation
 - ~~*[ignored]* `src/libsystemd/sd-bus/bus-bloom.h` [[link]](https://lgtm.com/projects/g/lnykryn/systemd-rhel/snapshot/f5844bf3f34f5e468c9c28487c37de607d85fab1/files/src/libsystemd/sd-bus/bus-bloom.c?sort=name&dir=ASC&mode=heatmap) - dropped from upstream along with kdbus~~
 - `src/shared/strv.c` [[link]](https://lgtm.com/projects/g/lnykryn/systemd-rhel/snapshot/f5844bf3f34f5e468c9c28487c37de607d85fab1/files/src/shared/strv.c?sort=name&dir=ASC&mode=heatmap#x90c37d31240b843a:1) - `strv_join_quoted` was dropped from upstream (replaced by a different approach) without resolving this issue; would require some, possibly substantial, refactoring
 - ~~*[ignored]* `src/bootchart/*` [[link]](https://lgtm.com/projects/g/lnykryn/systemd-rhel/snapshot/f5844bf3f34f5e468c9c28487c37de607d85fab1/files/src/bootchart/bootchart.c#x9c7e30d234d48467:1) - dropped from upstream (systemd/systemd@232c84b2d22f2d96982b3c0390d29498bb430835)~~
 - `src/core/execute.c` [[link]](https://lgtm.com/projects/g/lnykryn/systemd-rhel/snapshot/f5844bf3f34f5e468c9c28487c37de607d85fab1/files/src/core/execute.c?sort=name&dir=ASC&mode=heatmap#xbfa2ae16fedaa55f:1) - `process_execute` has been refactored to support longer process names (systemd/systemd@9bfaffd5a9c138b0bbdfb452b3f4435746f2d18b), not sure if it's worth backporting
 - ~~*[ignored]* `src/gudev/*` - dropped from upstream (systemd/systemd@2375607039517c88df51ef16ddbb624ec1c10654)~~
 - `src/shared/fw-util.c` [[link]](https://lgtm.com/projects/g/lnykryn/systemd-rhel/snapshot/f5844bf3f34f5e468c9c28487c37de607d85fab1/files/src/shared/fw-util.c#x62def701dfc13e50:1) - renamed to `src/shared/firewall-util.c`, however, not yet fixed in upstream

The *[ignored]* rules should *hopefully* take effect once this PR is merged.