### PR TITLE
(#1711876) core:scope: fix missing fragment_path

### DIFF
--- a/src/core/load-fragment.c
+++ b/src/core/load-fragment.c
@@ -3950,6 +3950,11 @@ int unit_load_fragment(Unit *u) {
         assert(u->load_state == UNIT_STUB);
         assert(u->id);
 
+        if (u->transient && u->fragment_path) {
+                u->load_state = UNIT_LOADED;
+                return 0;
+        }
+
         /* First, try to find the unit under its id. We always look
          * for unit files in the default directories, to make it easy
          * to override things by placing things in /etc/systemd/system */

--- a/src/core/scope.c
+++ b/src/core/scope.c
@@ -150,6 +150,10 @@ static int scope_load(Unit *u) {
         if (!u->transient && UNIT(s)->manager->n_reloading <= 0)
                 return -ENOENT;
 
+        r = unit_load_fragment(u);
+        if (r < 0)
+                return r;
+
         u->load_state = UNIT_LOADED;
 
         r = unit_load_dropin(u);


### PR DESCRIPTION
fragment_path in struct unit is a record of unit file, which will
be deleted (unlink) in unit_free().

After a daemon-reload process, the u->fragment_path of scope unit
will be missing (NULL). Then, the discarded session scope unit file
will be redundant until reboot.

Steps to Reproduce problem:
1. ssh access and login
2. systemctl daemon-reload
3. ssh logout
4. discarded session-xxx.scope file will be found in /run/systemd/system/

So in a daemon-reload case, scope_load() need unit_load_fragment() to reload
u->fragment_path.

(cherry picked from commit f838bf376249b68205641d1736da2622c0279ed2)

Resolves: #1711876