### PR TITLE
(#1711872) timer: we already got the trigger before, no need to call UNIT_TRIGGE…

### DIFF
--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -421,7 +421,7 @@ static void timer_enter_waiting(Timer *t, bool initial) {
 
                         case TIMER_UNIT_INACTIVE:
 
-                                base = UNIT_TRIGGER(UNIT(t))->inactive_enter_timestamp.monotonic;
+                                base = trigger->inactive_enter_timestamp.monotonic;
 
                                 if (base <= 0)
                                         base = t->last_trigger.monotonic;


### PR DESCRIPTION
…R again

In d7b2f6ef we forgot to replace this occurence.

rhel-only

(cherry picked from commit cfa30c21a4e5324a43695fcf43fe984aed2a8a8e)
Resolves: #1711872