### PR TITLE
(#1635945) udev/scsi_id: fix incorrect page length when get device identificatio…

### DIFF
--- a/src/udev/scsi_id/scsi_serial.c
+++ b/src/udev/scsi_id/scsi_serial.c
@@ -677,7 +677,7 @@ static int do_scsi_page83_inquiry(struct udev *udev,
                  * Examine each descriptor returned. There is normally only
                  * one or a small number of descriptors.
                  */
-                for (j = 4; j <= (unsigned int)page_83[3] + 3; j += page_83[j + 3] + 4) {
+                for (j = 4; j <= ((unsigned)page_83[2] << 8) + (unsigned)page_83[3] + 3; j += page_83[j + 3] + 4) {
                         retval = check_fill_0x83_id(udev,
                                                     dev_scsi, &page_83[j],
                                                     &id_search_list[id_ind],


### PR DESCRIPTION
…n VPD page

The length of device identification VPD page is filled with two bytes,
but scsi_id only gets the low byte. Fix it.

Signed-off-by: Zhang Xianwei <zhang.xianwei8@zte.com.cn>
(cherry picked from commit 1f7b6872dbe8ccae1f3bda9aa6aeb87c9b42e01e)

Resolves: #1635945