### PR TITLE
(#1703945) core:execute: fix fork() fail handling in exec_spawn()

### DIFF
--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -1870,7 +1870,7 @@ int exec_spawn(ExecCommand *command,
                         NULL);
         pid = fork();
         if (pid < 0)
-                return log_unit_error_errno(params->unit_id, r, "Failed to fork: %m");
+                return log_unit_error_errno(params->unit_id, errno, "Failed to fork: %m");
 
         if (pid == 0) {
                 int exit_status;


### PR DESCRIPTION
If pid < 0 after fork(), 0 is always returned because r =
exec_context_load_environment() has exited successfully.

This will make the caller of exec_spawn() not able to handle
the fork() error case and make systemd abort assert() possibly.

Cherry-picked from: 74129a127676e4f0edac0db4296c103e76ec6694
(cherry picked from commit 7ebf4a0faffecb3a0c8abe8bea47502044038d66)

Resolves: #1703945