### PR TITLE
(#1714782) fs-util: chase_symlinks(): prevent double free

### DIFF
--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -9414,8 +9414,6 @@ int chase_symlinks(const char *path, const char *original_root, unsigned flags, 
                                 if (fd < 0)
                                         return -errno;
 
-                                free(done);
-
                                 if (flags & CHASE_SAFE) {
                                         if (fstat(fd, &st) < 0)
                                                 return -errno;
@@ -9425,6 +9423,8 @@ int chase_symlinks(const char *path, const char *original_root, unsigned flags, 
 
                                         previous_stat = st;
                                 }
+
+                                free(done);
 
                                 /* Note that we do not revalidate the root, we take it as is. */
                                 if (isempty(root))


### PR DESCRIPTION
Fixes CID #1385316.

(cherry picked from commit b539437a056953cb0b537db4af61f1f1bf97ed44)

Resolves: #1714782