### PR TITLE
(#1685648) process: an empty environment block should be returned as such

### DIFF
--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -954,7 +954,13 @@ int get_process_environ(pid_t pid, char **env) {
                         sz += cescape_char(c, outcome + sz);
         }
 
-        outcome[sz] = '\0';
+        if (!outcome) {
+                outcome = strdup("");
+                if (!outcome)
+                        return -ENOMEM;
+        } else
+                outcome[sz] = '\0';
+
         *env = outcome;
         outcome = NULL;
 


### PR DESCRIPTION
An empty env block is completely valid, hence return it as such, and
don't turn it into an error.

(cherry picked from commit 03c55bc0b980e2a6aaf6f166a9271ed8ecce2222)

Resolves: #1685648