### PR TITLE
(#1729227) core: exclude .slice units from "systemctl isolate"

### DIFF
--- a/src/core/slice.c
+++ b/src/core/slice.c
@@ -36,6 +36,13 @@ static const UnitActiveState state_translation_table[_SLICE_STATE_MAX] = {
         [SLICE_ACTIVE] = UNIT_ACTIVE
 };
 
+static void slice_init(Unit *u) {
+        assert(u);
+        assert(u->load_state == UNIT_STUB);
+
+        u->ignore_on_isolate = true;
+}
+
 static void slice_set_state(Slice *t, SliceState state) {
         SliceState old_state;
         assert(t);
@@ -274,6 +281,7 @@ const UnitVTable slice_vtable = {
         .no_instances = true,
         .can_transient = true,
 
+        .init = slice_init,
         .load = slice_load,
 
         .coldplug = slice_coldplug,


### PR DESCRIPTION
Fixes: #1969
(cherry picked from commit 1b4cd0cf11feb7d41f2eff17f86fa55b31bb6841)

Related: #1729227