### PR TITLE
(#1641777) path: stop watching path specs once we triggered the target unit

### DIFF
--- a/src/core/path.c
+++ b/src/core/path.c
@@ -497,11 +497,9 @@ static void path_enter_running(Path *p) {
 
         p->inotify_triggered = false;
 
-        r = path_watch(p);
-        if (r < 0)
-                goto fail;
-
         path_set_state(p, PATH_RUNNING);
+        path_unwatch(p);
+
         return;
 
 fail:


### PR DESCRIPTION
We start watching them again once we get a notification that triggered
unit entered inactive or failed state.

Fixes: #10503
(cherry picked from commit 8fca6944c2ee20c63d62154c8badddc77170b176)

Resolves: #1641777