### PR TITLE
(#1770158) sd-bus: bump message queue size again

### DIFF
--- a/src/libsystemd/sd-bus/bus-internal.h
+++ b/src/libsystemd/sd-bus/bus-internal.h
@@ -326,8 +326,8 @@ struct sd_bus {
 
 #define BUS_DEFAULT_TIMEOUT ((usec_t) (25 * USEC_PER_SEC))
 
-#define BUS_WQUEUE_MAX (192*1024)
-#define BUS_RQUEUE_MAX (192*1024)
+#define BUS_WQUEUE_MAX (384*1024)
+#define BUS_RQUEUE_MAX (384*1024)
 
 #define BUS_MESSAGE_SIZE_MAX (128*1024*1024)
 #define BUS_AUTH_SIZE_MAX (64*1024)


### PR DESCRIPTION
Simliarly to issue #4068, the current limit turns out to be too small for a
big storage setup that uses many small disks. Let's bump it further.

Resolves: #1770158