### PR TITLE
(#1829754) core: coldplug possible nop_job

### DIFF
--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -2882,6 +2882,7 @@ static int unit_add_deserialized_job_coldplug(Unit *u) {
 
 int unit_coldplug(Unit *u, Hashmap *deferred_work) {
         int r;
+        Job *uj;
 
         assert(u);
 
@@ -2889,8 +2890,9 @@ int unit_coldplug(Unit *u, Hashmap *deferred_work) {
                 if ((r = UNIT_VTABLE(u)->coldplug(u, deferred_work)) < 0)
                         return r;
 
-        if (u->job) {
-                r = job_coldplug(u->job);
+        uj = u->job ?: u->nop_job;
+        if (uj) {
+                r = job_coldplug(uj);
                 if (r < 0)
                         return r;
         } else if (u->deserialized_job >= 0)


### PR DESCRIPTION
When a unit in a state INACTIVE or DEACTIVATING, JobType JOB_TRY_RESTART or
JOB_TRY_RELOAD will be collapsed to JOB_NOP. And use u->nop_job instead
of u->job.

If a JOB_NOP job is going on with a waiting state, a parallel daemon-reload
just install it during deserialization. Without a coldplug, the job will
not be in m->run_queue, which results in a hung try-restart or
try-reload process.

Reproduce:
1. run systemctl try-restart test.servcie (inactive) repeatly in a terminal.
2. run systemctl daemon-reload repeatly in other terminals.

After successful reproduce, systemctl list-jobs will list the hang job.

Upsteam:
https://github.com/systemd/systemd/pull/13124