### PR TITLE
(#1760149) unit: fix potential use of cgroup_path after free() when freeing unit

### DIFF
--- a/src/core/cgroup.c
+++ b/src/core/cgroup.c
@@ -874,8 +874,7 @@ void unit_destroy_cgroup_if_empty(Unit *u) {
 
         hashmap_remove(u->manager->cgroup_unit, u->cgroup_path);
 
-        free(u->cgroup_path);
-        u->cgroup_path = NULL;
+        u->cgroup_path = mfree(u->cgroup_path);
         u->cgroup_realized = false;
         u->cgroup_realized_mask = 0;
 }

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -515,7 +515,7 @@ void unit_free(Unit *u) {
 
         if (u->cgroup_path) {
                 hashmap_remove(u->manager->cgroup_unit, u->cgroup_path);
-                free(u->cgroup_path);
+                u->cgroup_path = mfree(u->cgroup_path);
         }
 
         set_remove(u->manager->failed_units, u);


### PR DESCRIPTION
Resolves: #1760149 - systemctl daemon-reload crashes systemd "free(): invalid next size (fast)" malloc