### PR TITLE
(#1693374) units: move Before deps for quota services to remote-fs.target

### DIFF
--- a/units/quotaon.service.in
+++ b/units/quotaon.service.in
@@ -10,7 +10,7 @@ Description=Enable File System Quotas
 Documentation=man:quotaon(8)
 DefaultDependencies=no
 After=systemd-readahead-collect.service systemd-readahead-replay.service systemd-quotacheck.service
-Before=local-fs.target shutdown.target
+Before=remote-fs.target shutdown.target
 ConditionPathExists=@QUOTAON@
 
 [Service]

--- a/units/systemd-quotacheck.service.in
+++ b/units/systemd-quotacheck.service.in
@@ -10,7 +10,7 @@ Description=File System Quota Check
 Documentation=man:systemd-quotacheck.service(8)
 DefaultDependencies=no
 After=systemd-readahead-collect.service systemd-readahead-replay.service systemd-remount-fs.service
-Before=local-fs.target shutdown.target
+Before=remote-fs.target shutdown.target
 ConditionPathExists=@QUOTACHECK@
 
 [Service]


### PR DESCRIPTION
Creating quota on an iscsi device is causing dependency loops at next reboot.
Reason is that systemd-quotacheck and quotaon.service are ordered before
local-fs.target and quota enabled mounts have a before dependency to them.
This cannot work for _netdev mounts, because network activation is ordered
after local-fs.target.
Moving the Before dependency for systemd-quotacheck and quotaon.service
to remote-fs.target fixes this.

(cherry picked from commit 4e6f13af93a551933a75331b1f67123b3d09f6ef)

Resolves: #1693374