### PR TITLE
(#1679934) core: downgrade log message about inability to propagate cgroup relea…

### DIFF
--- a/src/core/dbus.c
+++ b/src/core/dbus.c
@@ -93,7 +93,7 @@ int bus_forward_agent_released(Manager *m, const char *path) {
                                "Released",
                                "s", path);
         if (r < 0)
-                return log_warning_errno(r, "Failed to propagate agent release message: %m");
+                return log_debug_errno(r, "Failed to propagate agent release message: %m");
 
         return 1;
 }

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -1666,7 +1666,7 @@ static int manager_dispatch_cgroups_agent_fd(sd_event_source *source, int fd, ui
         buf[n] = 0;
 
         manager_notify_cgroup_empty(m, buf);
-        bus_forward_agent_released(m, buf);
+        (void) bus_forward_agent_released(m, buf);
 
         return 0;
 }


### PR DESCRIPTION
…se message

If dbus is already down during shutdown, we can't propagate the cgroup
release message anymore, but that's expected and nothing to warn about.
Hence let's downgrade the message from LOG_WARN to LOG_DEBUG.

Fixes: #6777
(cherry picked from commit d5f1532657da107f1c8be8a97c15d964cd96665c)

Resolves: #1679934