### PR TITLE
(#1786123) journal: fix syslog_parse_identifier()

### DIFF
--- a/src/journal/journald-syslog.c
+++ b/src/journal/journald-syslog.c
@@ -207,7 +207,7 @@ size_t syslog_parse_identifier(const char **buf, char **identifier, char **pid) 
         e = l;
         l--;
 
-        if (p[l-1] == ']') {
+        if (l > 0 && p[l-1] == ']') {
                 size_t k = l-1;
 
                 for (;;) {
@@ -232,8 +232,8 @@ size_t syslog_parse_identifier(const char **buf, char **identifier, char **pid) 
         if (t)
                 *identifier = t;
 
-        if (strchr(WHITESPACE, p[e]))
-                e++;
+        e += strspn(p + e, WHITESPACE);
+
         *buf = p + e;
         return e;
 }

--- a/src/journal/test-journal-syslog.c
+++ b/src/journal/test-journal-syslog.c
@@ -22,7 +22,7 @@
 #include "journald-syslog.h"
 #include "macro.h"
 
-static void test_syslog_parse_identifier(const char* str,
+static void test_syslog_parse_identifier(const char *str,
                                          const char *ident, const char*pid, int ret) {
         const char *buf = str;
         _cleanup_free_ char *ident2 = NULL, *pid2 = NULL;
@@ -38,7 +38,13 @@ static void test_syslog_parse_identifier(const char* str,
 int main(void) {
         test_syslog_parse_identifier("pidu[111]: xxx", "pidu", "111", 11);
         test_syslog_parse_identifier("pidu: xxx", "pidu", NULL, 6);
+        test_syslog_parse_identifier("pidu:  xxx", "pidu", NULL, 7);
         test_syslog_parse_identifier("pidu xxx", NULL, NULL, 0);
+        test_syslog_parse_identifier(":", "", NULL, 1);
+        test_syslog_parse_identifier(":  ", "", NULL, 3);
+        test_syslog_parse_identifier("pidu:", "pidu", NULL, 5);
+        test_syslog_parse_identifier("pidu: ", "pidu", NULL, 6);
+        test_syslog_parse_identifier("pidu : ", NULL, NULL, 0);
 
         return 0;
 }


### PR DESCRIPTION
Fixes #9829.

(cherry-picked from commit a6aadf4ae0bae185dc4c414d492a4a781c80ffe5)

[msekleta: Fix for CVE-2018-16866]

(cherry picked from commit ae50fe78923ca051175f0d86c84c544eb12aaa8d)

Resolves: #1786123