### PR TITLE
(#1799002) nss-util: silence warning about deprecated RES_USE_INET6

### DIFF
--- a/src/shared/nss-util.h
+++ b/src/shared/nss-util.h
@@ -25,6 +25,10 @@
 #include <netdb.h>
 #include <resolv.h>
 
+#ifndef DEPRECATED_RES_USE_INET6
+#  define DEPRECATED_RES_USE_INET6 0x00002000
+#endif
+
 #define NSS_GETHOSTBYNAME_PROTOTYPES(module)            \
 enum nss_status _nss_##module##_gethostbyname4_r(       \
                 const char *name,                       \
@@ -90,7 +94,7 @@ enum nss_status _nss_##module##_gethostbyname_r(        \
                 int *errnop, int *h_errnop) {           \
         enum nss_status ret = NSS_STATUS_NOTFOUND;      \
                                                         \
-        if (_res.options & RES_USE_INET6)               \
+        if (_res.options & DEPRECATED_RES_USE_INET6)    \
                 ret = _nss_##module##_gethostbyname3_r( \
                         name,                           \
                         AF_INET6,                       \


### PR DESCRIPTION
src/nss-resolve/nss-resolve.c: In function ‘_nss_resolve_gethostbyname_r’:
src/nss-resolve/nss-resolve.c:680:13: warning: RES_USE_INET6 is deprecated
 NSS_GETHOSTBYNAME_FALLBACKS(resolve);
             ^~~~~~~~~~~~~~~~~~~~~~~~~

In glibc bz #19582, RES_USE_INET6 was deprecated. This might make sense for
clients, but they didn't take into account nss module implementations which
*must* continue to support the option. glibc internally defines
DEPRECATED_RES_USE_INET6 which can be used without emitting a warning, but
it's not exported publicly. Let's do the same, and just copy the definition
to our header.

(cherry picked from commit 6154d33de3f15bbd5d5df718103af9c37ba0a768)