### PR TITLE
(#1786122) journal: do not remove multiple spaces after identifier in syslog mes…

### DIFF
--- a/src/journal/journald-syslog.c
+++ b/src/journal/journald-syslog.c
@@ -232,7 +232,9 @@ size_t syslog_parse_identifier(const char **buf, char **identifier, char **pid) 
         if (t)
                 *identifier = t;
 
-        e += strspn(p + e, WHITESPACE);
+        /* Single space is used as separator */
+        if (p[e] != '\0' && strchr(WHITESPACE, p[e]))
+                e++;
 
         *buf = p + e;
         return e;

--- a/src/journal/test-journal-syslog.c
+++ b/src/journal/test-journal-syslog.c
@@ -23,7 +23,7 @@
 #include "macro.h"
 
 static void test_syslog_parse_identifier(const char *str,
-                                         const char *ident, const char*pid, int ret) {
+                                         const char *ident, const char *pid, const char *rest, int ret) {
         const char *buf = str;
         _cleanup_free_ char *ident2 = NULL, *pid2 = NULL;
         int ret2;
@@ -33,18 +33,22 @@ static void test_syslog_parse_identifier(const char *str,
         assert_se(ret == ret2);
         assert_se(ident == ident2 || streq_ptr(ident, ident2));
         assert_se(pid == pid2 || streq_ptr(pid, pid2));
+        assert_se(streq(buf, rest));
 }
 
 int main(void) {
-        test_syslog_parse_identifier("pidu[111]: xxx", "pidu", "111", 11);
-        test_syslog_parse_identifier("pidu: xxx", "pidu", NULL, 6);
-        test_syslog_parse_identifier("pidu:  xxx", "pidu", NULL, 7);
-        test_syslog_parse_identifier("pidu xxx", NULL, NULL, 0);
-        test_syslog_parse_identifier(":", "", NULL, 1);
-        test_syslog_parse_identifier(":  ", "", NULL, 3);
-        test_syslog_parse_identifier("pidu:", "pidu", NULL, 5);
-        test_syslog_parse_identifier("pidu: ", "pidu", NULL, 6);
-        test_syslog_parse_identifier("pidu : ", NULL, NULL, 0);
+        test_syslog_parse_identifier("pidu[111]: xxx", "pidu", "111", "xxx", 11);
+        test_syslog_parse_identifier("pidu: xxx", "pidu", NULL, "xxx", 6);
+        test_syslog_parse_identifier("pidu:  xxx", "pidu", NULL, " xxx", 6);
+        test_syslog_parse_identifier("pidu xxx", NULL, NULL, "pidu xxx", 0);
+        test_syslog_parse_identifier("   pidu xxx", NULL, NULL, "   pidu xxx", 0);
+        test_syslog_parse_identifier("", NULL, NULL, "", 0);
+        test_syslog_parse_identifier("  ", NULL, NULL, "  ", 0);
+        test_syslog_parse_identifier(":", "", NULL, "", 1);
+        test_syslog_parse_identifier(":  ", "", NULL, " ", 2);
+        test_syslog_parse_identifier("pidu:", "pidu", NULL, "", 5);
+        test_syslog_parse_identifier("pidu: ", "pidu", NULL, "", 6);
+        test_syslog_parse_identifier("pidu : ", NULL, NULL, "pidu : ", 0);
 
         return 0;
 }


### PR DESCRIPTION
…sage

Single space is used as separator.
C.f. discussions in #156.

Fixes #9839 introduced by a6aadf4ae0bae185dc4c414d492a4a781c80ffe5.

(cherry-picked from commit 8595102d3ddde6d25c282f965573a6de34ab4421)
(cherry picked from commit 0adbe0fe7f1cb8703904c85fa095db8070503c04)
Related: #1786122