### PR TITLE
automount: rework propagation between automount and mount units

### DIFF
--- a/src/core/automount.h
+++ b/src/core/automount.h
@@ -64,8 +64,6 @@ struct Automount {
 
 extern const UnitVTable automount_vtable;
 
-int automount_update_mount(Automount *a, MountState old_state, MountState state);
-
 const char* automount_state_to_string(AutomountState i) _const_;
 AutomountState automount_state_from_string(const char *s) _pure_;
 

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -576,23 +576,6 @@ static int mount_load(Unit *u) {
         return mount_verify(m);
 }
 
-static int mount_notify_automount(Mount *m, MountState old_state, MountState state) {
-        Unit *p;
-        int r;
-        Iterator i;
-
-        assert(m);
-
-        SET_FOREACH(p, UNIT(m)->dependencies[UNIT_TRIGGERED_BY], i)
-                if (p->type == UNIT_AUTOMOUNT) {
-                         r = automount_update_mount(AUTOMOUNT(p), old_state, state);
-                         if (r < 0)
-                                 return r;
-                }
-
-        return 0;
-}
-
 static void mount_set_state(Mount *m, MountState state) {
         MountState old_state;
         assert(m);
@@ -615,8 +598,6 @@ static void mount_set_state(Mount *m, MountState state) {
                 m->control_command = NULL;
                 m->control_command_id = _MOUNT_EXEC_COMMAND_INVALID;
         }
-
-        mount_notify_automount(m, old_state, state);
 
         if (state != old_state)
                 log_unit_debug(UNIT(m)->id,


### PR DESCRIPTION
Port the progagation logic to the generic Unit->trigger_notify() callback logic
in the unit vtable, that is called for a unit not only when the triggered unit
of it changes state but also when a job for that unit finishes. This, firstly
allows us to make the code a bit cleaner and more generic, but more
importantly, allows us to notice correctly when a mount job fails, and
propagate that back to autofs client processes.

Fixes: #2181
(cherry picked from commit fae03ed32a77934a5c39ed8e338ec6c7a75857a0)

Resolves: #1739172