### PR TITLE
(#1798503) bus_open leak sd_event_source when udevadm trigger。

### DIFF
--- a/src/login/logind-button.c
+++ b/src/login/logind-button.c
@@ -259,6 +259,7 @@ int button_open(Button *b) {
                 goto fail;
         }
 
+        b->io_event_source = sd_event_source_unref(b->io_event_source);
         r = sd_event_add_io(b->manager->event, &b->io_event_source, b->fd, EPOLLIN, button_dispatch, b);
         if (r < 0) {
                 log_error_errno(r, "Failed to add button event: %m");


### PR DESCRIPTION
On my host, when executing the udevadm trigger, I only receive the change event, which causes memleak

(cherry picked from commit b2774a3ae692113e1f47a336a6c09bac9cfb49ad)

Resolves: #1798503