### PR TITLE
(#1807798) journal: do not trigger assertion when journal_file_close() get NULL

### DIFF
--- a/src/journal/journal-file.c
+++ b/src/journal/journal-file.c
@@ -129,7 +129,8 @@ int journal_file_set_offline(JournalFile *f) {
 }
 
 void journal_file_close(JournalFile *f) {
-        assert(f);
+        if (!f)
+                return;
 
 #ifdef HAVE_GCRYPT
         /* Write the final tag */

--- a/src/journal/journald-server.c
+++ b/src/journal/journald-server.c
@@ -1933,11 +1933,8 @@ void server_done(Server *s) {
         while (s->stdout_streams)
                 stdout_stream_free(s->stdout_streams);
 
-        if (s->system_journal)
-                journal_file_close(s->system_journal);
-
-        if (s->runtime_journal)
-                journal_file_close(s->runtime_journal);
+        (void) journal_file_close(s->system_journal);
+        (void) journal_file_close(s->runtime_journal);
 
         while ((f = ordered_hashmap_steal_first(s->user_journals)))
                 journal_file_close(f);


### PR DESCRIPTION
We generally expect destructors to not complain if a NULL argument is passed.

Closes #12400.

(cherry picked from commit c377a6f3ad3d9bed4ce7e873e8e9ec6b1650c57d)
(cherry picked from commit 248925c68092bab7ce0231449176db153f55d818)
Resolves: #1807798