### PR TITLE
(#1811700) Consider smb3 as remote filesystem

### DIFF
--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -1937,6 +1937,7 @@ bool fstype_is_network(const char *fstype) {
         static const char table[] =
                 "afs\0"
                 "cifs\0"
+                "smb3\0"
                 "smbfs\0"
                 "sshfs\0"
                 "ncpfs\0"


### PR DESCRIPTION
Currently systemd will treat smb3 as local filesystem and cause
can't boot failures. Add smb3 to the list of remote filesystems
to fix this issue.

Signed-off-by: Kenneth D'souza <kdsouza@redhat.com>
(cherry picked from commit ff7d6a740b0c6fa3be63d3908a0858730a0837c5)

Resolves: #1811700