### PR TITLE
(#1809159) fix the fix for #1691511

### DIFF
--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1416,6 +1416,7 @@ static int mount_setup_unit(
         bool load_extras = false;
         MountParameters *p;
         bool delete, changed = false;
+        bool just_mounted;
         Unit *u;
         int r;
 
@@ -1489,6 +1490,7 @@ static int mount_setup_unit(
                  * loaded in now. */
                 unit_add_to_load_queue(u);
                 changed = true;
+                just_mounted = true;
         } else {
                 delete = false;
 
@@ -1518,6 +1520,8 @@ static int mount_setup_unit(
                         load_extras = true;
                         changed = true;
                 }
+
+                just_mounted = !MOUNT(u)->from_proc_self_mountinfo || MOUNT(u)->just_mounted;
         }
 
         w = strdup(what);
@@ -1537,7 +1541,7 @@ static int mount_setup_unit(
 
         if (set_flags) {
                 MOUNT(u)->is_mounted = true;
-                MOUNT(u)->just_mounted = !MOUNT(u)->from_proc_self_mountinfo || MOUNT(u)->just_mounted;
+                MOUNT(u)->just_mounted = just_mounted;
                 MOUNT(u)->just_changed = changed;
         }
 


### PR DESCRIPTION
The fix for #1691511 should have been used only for existing mounts
(mount_setup_existing_unit() in current master).

(cherry picked from commit 4584818bea998d257a166c238b829025b6138e55)

Related: #1809159