### PR TITLE
(#1813270) mount: don't add Requires for tmp.mount

### DIFF
--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -300,7 +300,7 @@ static int mount_add_mount_links(Mount *m) {
                 if (r < 0)
                         return r;
 
-                if (UNIT(m)->fragment_path) {
+                if (UNIT(m)->fragment_path && !streq(UNIT(m)->id, "tmp.mount")) {
                         /* If we have fragment configuration, then make this dependency required */
                         r = unit_add_dependency(other, UNIT_REQUIRES, UNIT(m), true);
                         if (r < 0)


### PR DESCRIPTION
This is a follow-up to #1372249.

rhel-only
Resolves: #1813270