### PR TITLE
(#1825232) core: fix unnecessary fallback to the rescue mode caused by initrd-sw…

### DIFF
--- a/src/shared/special.h
+++ b/src/shared/special.h
@@ -96,6 +96,7 @@
 #define SPECIAL_QUOTACHECK_SERVICE "systemd-quotacheck.service"
 #define SPECIAL_QUOTAON_SERVICE "quotaon.service"
 #define SPECIAL_REMOUNT_FS_SERVICE "systemd-remount-fs.service"
+#define SPECIAL_INITRD_SWITCH_ROOT_SERVICE "initrd-switch-root.service"
 
 /* Services systemd relies on */
 #define SPECIAL_DBUS_SERVICE "dbus.service"


### PR DESCRIPTION
core: fix unnecessary fallback to the rescue mode caused by initrd-switch-root.service's exit status judgment error

commit 1f0958f ("core: when determining whether a process exit
status is clean, consider whether it is a command or a daemon")
introduces a side effect that causes system falls into rescure mode
due initrd-switch-root.service entered failed state, detailed
information should refer to the redhat's doc, as follows:
https://access.redhat.com/solutions/4973191
https://bugzilla.redhat.com/show_bug.cgi?id=1414904

As we know that in the cloud computing scenarios, some very critical
services may run on the server, and the server may run continuously for
several years without restarting.The initramfske may still maintain the
original state many years ago without any changes. In addition, this
server may have been installed a lot of user mode programs and kernel
mode drivers due to various operations and maintenance over the years.

If the initramfs is regenerated because of upgrading systemd, the user-mode
programs or drivers previously installed may be inserted into the initramfs,
introducing unknown risks, and may even cause the system to fail to start.
So we hope that this patch may avoid the above issues.

Resolves: #1825232