### PR TITLE
mount-setup: change the system mount propagation to shared by default only at bootup

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1421,7 +1421,7 @@ int main(int argc, char *argv[]) {
                 if (!skip_setup)
                         kmod_setup();
 
-                r = mount_setup(loaded_policy);
+                r = mount_setup(loaded_policy, skip_setup);
                 if (r < 0) {
                         error_message = "Failed to mount API filesystems";
                         goto finish;

--- a/src/core/mount-setup.c
+++ b/src/core/mount-setup.c
@@ -369,7 +369,7 @@ static int relabel_cgroup_filesystems(void) {
 }
 #endif
 
-int mount_setup(bool loaded_policy) {
+int mount_setup(bool loaded_policy, bool leave_propagation) {
         unsigned i;
         int r = 0;
 
@@ -422,7 +422,7 @@ int mount_setup(bool loaded_policy) {
          * nspawn and the container tools work out of the box. If
          * specific setups need other settings they can reset the
          * propagation mode to private if needed. */
-        if (detect_container(NULL) <= 0)
+        if (detect_container(NULL) <= 0 && !leave_propagation)
                 if (mount(NULL, "/", NULL, MS_REC|MS_SHARED, NULL) < 0)
                         log_warning_errno(errno, "Failed to set up the root directory for shared mount propagation: %m");
 

--- a/src/core/mount-setup.h
+++ b/src/core/mount-setup.h
@@ -24,7 +24,7 @@
 #include <stdbool.h>
 
 int mount_setup_early(void);
-int mount_setup(bool loaded_policy);
+int mount_setup(bool loaded_policy, bool leave_propagation);
 
 int mount_cgroup_controllers(char ***join_controllers);
 


### PR DESCRIPTION
The commit b3ac5f8cb987 has changed the system mount propagation to
shared by default, and according to the following patch:
https://github.com/opencontainers/runc/pull/208
When starting the container, the pouch daemon will call runc to execute
make-private.

However, if the systemctl daemon-reexec is executed after the container
has been started, the system mount propagation will be changed to share
again by default, and the make-private operation above will have no chance
to execute.

(cherry picked from commit f74349d88bb039a134b225653e8e59d04af4bb7f)
Signed-off-by: Yuanhong Peng <yummypeng@linux.alibaba.com>