### PR TITLE
(RHEL-17164) call chase_symlinks without the /sysroot prefix (#6411)

### DIFF
--- a/src/fstab-generator/fstab-generator.c
+++ b/src/fstab-generator/fstab-generator.c
@@ -455,7 +455,7 @@ static int parse_fstab(bool initrd) {
                         continue;
                 }
 
-                where = initrd ? strappend("/sysroot/", me->mnt_dir) : strdup(me->mnt_dir);
+                where = strdup(me->mnt_dir);
                 if (!where)
                         return log_oom();
 


### PR DESCRIPTION
In case fstab-generator is called in the initrd, chase_symlinks() returns with a canonical path "/sysroot/sysroot/<mountpoint>", if the "/sysroot" prefix is present in the path.

This patch skips the "/sysroot" prefix for the chase_symlinks() call, because "/sysroot" is already the root directory and chase_symlinks() prepends the root directory in the canonical path returned.

(cherry picked from commit 98eda38aed6a10c4f6d6ad0cac6e5361e87de52b)

Resolves: RHEL-17164