### PR TITLE
(RHEL-17164) Revert "fstab-generator: Chase symlinks where possible (#6293)"

### DIFF
--- a/man/systemd-fstab-generator.xml
+++ b/man/systemd-fstab-generator.xml
@@ -71,14 +71,6 @@
     for more information about special <filename>/etc/fstab</filename>
     mount options this generator understands.</para>
 
-    <para>One special topic is handling of symbolic links.  Historical init
-    implementations supported symlinks in <filename>/etc/fstab</filename>.
-    Because mount units will refuse mounts where the target is a symbolic link,
-    this generator will resolve any symlinks as far as possible when processing
-    <filename>/etc/fstab</filename> in order to enhance backwards compatibility.
-    If a symlink target does not exist at the time that this generator runs, it
-    is assumed that the symlink target is the final target of the mount.</para>
-
     <para><filename>systemd-fstab-generator</filename> implements
     <citerefentry><refentrytitle>systemd.generator</refentrytitle><manvolnum>7</manvolnum></citerefentry>.</para>
   </refsect1>

--- a/man/systemd.mount.xml
+++ b/man/systemd.mount.xml
@@ -295,9 +295,8 @@
 
       <varlistentry>
         <term><varname>Where=</varname></term>
-        <listitem><para>Takes an absolute path of a directory for the
-        mount point; in particular, the destination cannot be a symbolic
-        link.  If the mount point does not exist at the time of
+        <listitem><para>Takes an absolute path of a directory of the
+        mount point. If the mount point does not exist at the time of
         mounting, it is created. This string must be reflected in the
         unit filename. (See above.) This option is
         mandatory.</para></listitem>


### PR DESCRIPTION
This reverts commit a4c51f1bb38f272fb9c3dbaa33f1f383639ce345.

Resolves: RHEL-17164