### PR TITLE
(RHEL-17394) fstab-generator: Chase symlinks where possible

### DIFF
--- a/man/systemd-fstab-generator.xml
+++ b/man/systemd-fstab-generator.xml
@@ -71,6 +71,14 @@
     for more information about special <filename>/etc/fstab</filename>
     mount options this generator understands.</para>
 
+    <para>One special topic is handling of symbolic links.  Historical init
+    implementations supported symlinks in <filename>/etc/fstab</filename>.
+    Because mount units will refuse mounts where the target is a symbolic link,
+    this generator will resolve any symlinks as far as possible when processing
+    <filename>/etc/fstab</filename> in order to enhance backwards compatibility.
+    If a symlink target does not exist at the time that this generator runs, it
+    is assumed that the symlink target is the final target of the mount.</para>
+
     <para><filename>systemd-fstab-generator</filename> implements
     <citerefentry><refentrytitle>systemd.generator</refentrytitle><manvolnum>7</manvolnum></citerefentry>.</para>
   </refsect1>

--- a/man/systemd.mount.xml
+++ b/man/systemd.mount.xml
@@ -295,8 +295,9 @@
 
       <varlistentry>
         <term><varname>Where=</varname></term>
-        <listitem><para>Takes an absolute path of a directory of the
-        mount point. If the mount point does not exist at the time of
+        <listitem><para>Takes an absolute path of a directory for the
+        mount point; in particular, the destination cannot be a symbolic
+        link.  If the mount point does not exist at the time of
         mounting, it is created. This string must be reflected in the
         unit filename. (See above.) This option is
         mandatory.</para></listitem>

--- a/src/escape/escape.c
+++ b/src/escape/escape.c
@@ -99,7 +99,7 @@ static int parse_argv(int argc, char *argv[]) {
 
                 case ARG_TEMPLATE:
 
-                        if (!unit_name_is_valid(optarg, true) || !unit_name_is_template(optarg)) {
+                        if (!unit_name_is_valid(optarg, UNIT_NAME_TEMPLATE) || !unit_name_is_template(optarg)) {
                                 log_error("Template name %s is not valid.", optarg);
                                 return -EINVAL;
                         }

--- a/src/fstab-generator/fstab-generator.c
+++ b/src/fstab-generator/fstab-generator.c
@@ -455,7 +455,7 @@ static int parse_fstab(bool initrd) {
                         continue;
                 }
 
-                where = initrd ? strappend("/sysroot/", me->mnt_dir) : strdup(me->mnt_dir);
+                where = strdup(me->mnt_dir);
                 if (!where)
                         return log_oom();
 

--- a/src/fstab-generator/fstab-generator.c
+++ b/src/fstab-generator/fstab-generator.c
@@ -611,7 +611,7 @@ static int add_sysroot_usr_mount(void) {
                          false,
                          false,
                          false,
-                         SPECIAL_INITRD_ROOT_FS_TARGET,
+                         SPECIAL_INITRD_FS_TARGET,
                          "/proc/cmdline");
 }
 

--- a/src/fstab-generator/fstab-generator.c
+++ b/src/fstab-generator/fstab-generator.c
@@ -240,6 +240,7 @@ static int write_idle_timeout(FILE *f, const char *where, const char *opts) {
 static int add_mount(
                 const char *what,
                 const char *where,
+                const char *original_where,
                 const char *fstype,
                 const char *opts,
                 int passno,
@@ -329,10 +330,12 @@ static int add_mount(
         fprintf(f,
                 "\n"
                 "[Mount]\n"
-                "What=%s\n"
-                "Where=%s\n",
-                what,
-                where);
+                "What=%s\n",
+                what);
+
+        if (original_where)
+                fprintf(f, "# Canonicalized from %s\n", original_where);
+        fprintf(f, "Where=%s\n", where);
 
         if (!isempty(fstype) && !streq(fstype, "auto"))
                 fprintf(f, "Type=%s\n", fstype);
@@ -436,7 +439,7 @@ static int parse_fstab(bool initrd) {
         }
 
         while ((me = getmntent(f))) {
-                _cleanup_free_ char *where = NULL, *what = NULL;
+                _cleanup_free_ char *where = NULL, *what = NULL, *canonical_where = NULL;
                 bool noauto, nofail;
                 int k;
 
@@ -456,8 +459,28 @@ static int parse_fstab(bool initrd) {
                 if (!where)
                         return log_oom();
 
-                if (is_path(where))
+                if (is_path(where)) {
                         path_kill_slashes(where);
+                        /* Follow symlinks here; see 5261ba901845c084de5a8fd06500ed09bfb0bd80 which makes sense for
+                         * mount units, but causes problems since it historically worked to have symlinks in e.g.
+                         * /etc/fstab. So we canonicalize here. Note that we use CHASE_NONEXISTENT to handle the case
+                         * where a symlink refers to another mount target; this works assuming the sub-mountpoint
+                         * target is the final directory.
+                         */
+                        r = chase_symlinks(where, initrd ? "/sysroot" : NULL,
+                                           CHASE_PREFIX_ROOT | CHASE_NONEXISTENT,
+                                           &canonical_where);
+                        if (r < 0)
+                                /* In this case for now we continue on as if it wasn't a symlink */
+                                log_warning_errno(r, "Failed to read symlink target for %s: %m", where);
+                        else {
+                                if (streq(canonical_where, where))
+                                        canonical_where = mfree(canonical_where);
+                                else
+                                        log_debug("Canonicalized what=%s where=%s to %s",
+                                                  what, where, canonical_where);
+                        }
+                }
 
                 noauto = fstab_test_yes_no_option(me->mnt_opts, "noauto\0" "auto\0");
                 nofail = fstab_test_yes_no_option(me->mnt_opts, "nofail\0" "fail\0");
@@ -482,7 +505,8 @@ static int parse_fstab(bool initrd) {
                                 post = SPECIAL_LOCAL_FS_TARGET;
 
                         k = add_mount(what,
-                                      where,
+                                      canonical_where ?: where,
+                                      canonical_where ? where: NULL,
                                       me->mnt_type,
                                       me->mnt_opts,
                                       me->mnt_passno,
@@ -526,6 +550,7 @@ static int add_sysroot_mount(void) {
         log_debug("Found entry what=%s where=/sysroot type=%s", what, strna(arg_root_fstype));
         return add_mount(what,
                          "/sysroot",
+                         NULL,
                          arg_root_fstype,
                          opts,
                          1,
@@ -583,6 +608,7 @@ static int add_sysroot_usr_mount(void) {
         log_debug("Found entry what=%s where=/sysroot/usr type=%s", what, strna(arg_usr_fstype));
         return add_mount(what,
                          "/sysroot/usr",
+                         NULL,
                          arg_usr_fstype,
                          opts,
                          1,

--- a/test/TEST-81-GENERATORS/Makefile
+++ b/test/TEST-81-GENERATORS/Makefile
@@ -1,0 +1,1 @@
+../TEST-01-BASIC/Makefile

--- a/test/TEST-81-GENERATORS/generator-utils.sh
+++ b/test/TEST-81-GENERATORS/generator-utils.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+link_endswith() {
+    [[ -h "${1:?}" && "$(readlink "${1:?}")" =~ ${2:?}$ ]]
+}
+
+link_eq() {
+    [[ -h "${1:?}" && "$(readlink "${1:?}")" == "${2:?}" ]]
+}
+
+# Get the value from a 'key=value' assignment
+opt_get_arg() {
+    local arg
+
+    IFS="=" read -r _ arg <<< "${1:?}"
+    test -n "$arg"
+    echo "$arg"
+}
+
+in_initrd() {
+    [[ "${SYSTEMD_IN_INITRD:-0}" -ne 0 ]]
+}
+
+# Check if we're parsing host's fstab in initrd
+in_initrd_host() {
+    in_initrd && [[ "${SYSTEMD_SYSROOT_FSTAB:-/dev/null}" != /dev/null ]]
+}
+
+in_container() {
+    systemd-detect-virt -qc
+}
+
+opt_filter() (
+    set +x
+    local opt split_options filtered_options
+
+    IFS="," read -ra split_options <<< "${1:?}"
+    for opt in "${split_options[@]}"; do
+        if [[ "$opt" =~ ${2:?} ]]; then
+            continue
+        fi
+
+        filtered_options+=("$opt")
+    done
+
+    IFS=","; printf "%s" "${filtered_options[*]}"
+)
+
+# Run the given generator $1 with target directory $2 - clean the target
+# directory beforehand
+run_and_list() {
+    local generator="${1:?}"
+    local out_dir="${2:?}"
+    local environ
+    local cmdline
+
+    # If $PID1_ENVIRON is set temporarily overmount /proc/1/environ with
+    # a temporary file that contains contents of $PID1_ENVIRON. This is
+    # necessary in cases where the generator reads the environment through
+    # getenv_for_pid(1, ...) or similar like getty-generator does.
+    #
+    # Note: $PID1_ENVIRON should be a NUL separated list of env assignments
+    if [[ -n "${PID1_ENVIRON:-}" ]]; then
+        environ="$(mktemp)"
+        echo -ne "${PID1_ENVIRON}\0" >"${environ:?}"
+        mount -v --bind "$environ" /proc/1/environ
+    fi
+
+    if [[ -n "${SYSTEMD_PROC_CMDLINE:-}" ]]; then
+        cmdline="$(mktemp)"
+        echo "$SYSTEMD_PROC_CMDLINE" >"$cmdline"
+        mount --bind "$cmdline" /proc/cmdline
+    fi
+
+    if [[ -n "${SYSTEMD_FSTAB:-}" ]]; then
+        touch /etc/fstab
+        mount --bind "$SYSTEMD_FSTAB" /etc/fstab
+    fi
+
+    if [[ -n "${SYSTEMD_SYSROOT_FSTAB:-}" ]]; then
+        mkdir -p /sysroot/etc
+        touch /sysroot/etc/fstab
+        mount --bind "$SYSTEMD_SYSROOT_FSTAB" /sysroot/etc/fstab
+    fi
+
+    rm -fr "${out_dir:?}"/*
+    mkdir -p "$out_dir"/{normal,early,late}
+    SYSTEMD_LOG_LEVEL="${SYSTEMD_LOG_LEVEL:-debug}" "$generator" "$out_dir/normal" "$out_dir/early" "$out_dir/late"
+    ls -lR "$out_dir"
+
+    if [[ -n "${SYSTEMD_SYSROOT_FSTAB:-}" ]]; then
+        umount /sysroot/etc/fstab
+        rm -rf /sysroot
+    fi
+
+    if [[ -n "${SYSTEMD_FSTAB:-}" ]]; then
+        umount /etc/fstab
+    fi
+
+    if [[ -n "${SYSTEMD_PROC_CMDLINE:-}" ]]; then
+        umount /proc/cmdline
+        rm -f "$cmdline"
+    fi
+
+    if [[ -n "${environ:-}" ]]; then
+        umount /proc/1/environ
+        rm -f "$environ"
+    fi
+}

--- a/test/TEST-81-GENERATORS/test.sh
+++ b/test/TEST-81-GENERATORS/test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/bash
+TEST_DESCRIPTION="Test systemd generators"
+
+# shellcheck source=test/test-functions
+. "$TEST_BASE_DIR/test-functions"
+
+check_result_qemu() {
+    ret=1
+    mkdir -p $TESTDIR/root
+    mount ${LOOPDEV}p1 $TESTDIR/root
+    [[ -e $TESTDIR/root/testok ]] && ret=0
+    [[ -f $TESTDIR/root/failed ]] && cp -a $TESTDIR/root/failed $TESTDIR
+    [[ -f $TESTDIR/root/var/log/journal ]] && cp -a $TESTDIR/root/var/log/journal $TESTDIR
+    umount $TESTDIR/root
+    [[ -f $TESTDIR/failed ]] && cat $TESTDIR/failed
+    ls -l $TESTDIR/journal/*/*.journal
+    test -s $TESTDIR/failed && ret=$(($ret+1))
+    return $ret
+}
+
+test_run() {
+    if run_qemu; then
+        check_result_qemu || return 1
+    else
+        dwarn "can't run QEMU, skipping"
+    fi
+    if check_nspawn; then
+        run_nspawn
+        check_result_nspawn || return 1
+    else
+        dwarn "can't run systemd-nspawn, skipping"
+    fi
+    return 0
+}
+
+test_setup() {
+    create_empty_image
+    mkdir -p "${TESTDIR:?}/root"
+    mount "${LOOPDEV:?}p1" "$TESTDIR/root"
+
+    (
+        LOG_LEVEL=5
+        # shellcheck disable=SC2046
+        eval $(udevadm info --export --query=env --name="${LOOPDEV}p2")
+
+        setup_basic_environment
+
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null "$initdir/etc/systemd/system/systemd-hwdb-update.service"
+        ln -fs /dev/null "$initdir/etc/systemd/system/systemd-journal-catalog-update.service"
+        ln -fs /dev/null "$initdir/etc/systemd/system/systemd-networkd.service"
+        ln -fs /dev/null "$initdir/etc/systemd/system/systemd-networkd.socket"
+        ln -fs /dev/null "$initdir/etc/systemd/system/systemd-resolved.service"
+        ln -fs /dev/null "$initdir/etc/systemd/system/systemd-machined.service"
+
+        # setup the testsuite service
+        cat >"$initdir/etc/systemd/system/testsuite.service" <<EOF
+[Unit]
+Description=Testsuite service
+
+[Service]
+ExecStart=/bin/bash -x /testsuite.sh
+Type=oneshot
+StandardOutput=tty
+StandardError=tty
+NotifyAccess=all
+EOF
+        cp generator-utils.sh testsuite*.sh "$initdir/"
+
+        setup_testsuite
+    ) || return 1
+    setup_nspawn_root
+
+    ddebug "umount $TESTDIR/root"
+    umount "$TESTDIR/root"
+}
+
+test_cleanup() {
+    umount $TESTDIR/root 2>/dev/null
+    [[ $LOOPDEV ]] && losetup -d $LOOPDEV
+    return 0
+}
+
+do_test "$@"

--- a/test/TEST-81-GENERATORS/testsuite.fstab-generator.sh
+++ b/test/TEST-81-GENERATORS/testsuite.fstab-generator.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# shellcheck disable=SC2235,SC2233
+set -ex
+set -o pipefail
+
+# shellcheck source=test/TEST-81-GENERATORS/generator-utils.sh
+. "$(dirname "$0")/generator-utils.sh"
+
+GENERATOR_BIN="/usr/lib/systemd/system-generators/systemd-fstab-generator"
+NETWORK_FS_RX="^(afs|ceph|cifs|gfs|gfs2|ncp|ncpfs|nfs|nfs4|ocfs2|orangefs|pvfs2|smb3|smbfs|davfs|glusterfs|lustre|sshfs)$"
+OUT_DIR="$(mktemp -d /tmp/fstab-generator.XXX)"
+FSTAB="$(mktemp)"
+
+at_exit() {
+    rm -fr "${OUT_DIR:?}" "${FSTAB:?}"
+}
+
+trap at_exit EXIT
+
+test -x "${GENERATOR_BIN:?}"
+
+# RHEL 7: the various links we create on RHEL 7 are in most cases absolute, not relative
+
+FSTAB_GENERAL=(
+    # Valid entries
+    "/dev/test2     /nofail                             ext4        nofail 0 0"
+    "/dev/test3     /regular                            btrfs       defaults 0 0"
+    "/dev/test4     /x-systemd.requires                 xfs         x-systemd.requires=foo.service 0 0"
+# Not supported on RHEL 7
+#    "/dev/test5     /x-systemd.before-after             xfs         x-systemd.before=foo.service,x-systemd.after=bar.mount 0 0"
+# Not supported on RHEL7
+#    "/dev/test6     /x-systemd.wanted-required-by       xfs         x-systemd.wanted-by=foo.service,x-systemd.required-by=bar.device 0 0"
+    "/dev/test7     /x-systemd.requires-mounts-for      xfs         x-systemd.requires-mounts-for=/foo/bar/baz 0 0"
+    "/dev/test8     /x-systemd.automount-idle-timeout   vfat        x-systemd.automount,x-systemd.idle-timeout=50s 0 0"
+# Not supported on RHEL 7
+#    "/dev/test9     /x-systemd.makefs                   xfs         x-systemd.makefs 0 0"
+#    "/dev/test10    /x-systemd.growfs                   xfs         x-systemd.growfs 0 0"
+    "/dev/test11    /_netdev                            ext4        defaults,_netdev 0 0"
+# Not supported on RHEL7
+#    "/dev/test12    /_rwonly                            ext4        x-systemd.rw-only 0 0"
+#    "/dev/test13    /chaos1                             zfs         x-systemd.requires=hello.service,x-systemd.after=my.device 0 0"
+#    "/dev/test14    /chaos2                             zfs         x-systemd.growfs,x-systemd.makefs 0 0"
+    "/dev/test15    /fstype/auto                        auto        defaults 0 0"
+    "/dev/test16    /fsck/me                            ext4        defaults 0 1"
+    "/dev/test17    /also/fsck/me                       ext4        defaults,x-systemd.requires-mounts-for=/var/lib/foo 0 99"
+    "/dev/test18    /swap                               swap        defaults 0 0"
+# Not supported on RHEL 7
+#    "/dev/test19    /swap/makefs                        swap        defaults,x-systemd.makefs 0 0"
+# RHEL 7 systemd sets JobTimeoutSec=3600 for x-systemd.device-timeout=1h, so make our lives easier and use seconds here as well
+    "/dev/test20    /var                                xfs         defaults,x-systemd.device-timeout=3600 0 0"
+    "/dev/test21    /usr                                ext4        defaults 0 1"
+    "/dev/test22    /initrd/mount                       ext2        defaults,x-initrd.mount 0 1"
+    "/dev/test23    /initrd/mount/nofail                ext3        defaults,nofail,x-initrd.mount 0 1"
+# Not supported on RHEL 7
+#    "/dev/test24    /initrd/mount/deps                  ext4        x-initrd.mount,x-systemd.before=early.service,x-systemd.after=late.service 0 1"
+
+    # Incomplete, but valid entries
+    "/dev/incomplete1 /incomplete1"
+    "/dev/incomplete2 /incomplete2                      ext4"
+    "/dev/incomplete3 /incomplete3                      ext4        defaults"
+    "/dev/incomplete4 /incomplete4                      ext4        defaults 0"
+
+    # Remote filesystems
+    "/dev/remote1   /nfs                                nfs         bg 0 0"
+    "/dev/remote2   /nfs4                               nfs4        bg 0 0"
+    "bar.tld:/store /remote/storage                     nfs         ro 0 0"
+    "user@host.tld:/remote/dir /remote/top-secret       sshfs       rw 0 0"
+# ceph is not a remote FS for RHEL 7 systemd
+#    "foo.tld:/hello /hello/world                        ceph        defaults 0 0"
+    "//192.168.0.1/storage /cifs-storage                cifs        automount,nofail 0 0"
+)
+
+FSTAB_GENERAL_ROOT=(
+    # rootfs with bunch of options we should ignore and fsck enabled
+    "/dev/test1     /                                   ext4        noauto,nofail,x-systemd.automount,x-systemd.wanted-by=foo,x-systemd.required-by=bar 0 1"
+    "${FSTAB_GENERAL[@]}"
+)
+
+FSTAB_MINIMAL=(
+    "/dev/loop1     /foo/bar                            ext3        defaults 0 0"
+)
+
+FSTAB_DUPLICATE=(
+    "/dev/dup1     /       ext4 defaults 0 1"
+    "/dev/dup2     /       ext4 defaults,x-systemd.requires=foo.mount 0 2"
+)
+
+FSTAB_INVALID=(
+    # Ignored entries
+    "/dev/ignored1  /sys/fs/cgroup/foo                  ext4        defaults    0 0"
+    "/dev/ignored2  /sys/fs/selinux                     ext4        defaults    0 0"
+    "/dev/ignored3  /dev/console                        ext4        defaults    0 0"
+    "/dev/ignored4  /proc/kmsg                          ext4        defaults    0 0"
+    "/dev/ignored5  /proc/sys                           ext4        defaults    0 0"
+# Not ignored on RHEL7, see 6f997852c8830ca073c55241b0068ebbf1f94a72
+#    "/dev/ignored6  /proc/sys/kernel/random/boot_id     ext4        defaults    0 0"
+#    "/dev/ignored7  /run/host                           ext4        defaults    0 0"
+#    "/dev/ignored8  /run/host/foo                       ext4        defaults    0 0"
+    "/dev/ignored9  /autofs                             autofs      defaults    0 0"
+    "/dev/invalid1  not-a-path                          ext4        defaults    0 0"
+    ""
+    "/dev/invalid1"
+    "			"
+    "\\"
+    "$"
+)
+
+check_fstab_mount_units() {
+    local what where fstype opts passno unit
+    local item opt split_options filtered_options supp service device arg
+    local out_dir="${1:?}/normal"
+    shift
+
+    # Running the checks in a container is pretty much useless, since we don't
+    # generate any mounts, but don't skip the whole test to test the "skip"
+    # paths as well
+    in_container && return 0
+
+    for item in "$@"; do
+        # Don't use a pipe here, as it would make the variables out of scope
+        read -r what where fstype opts _ passno <<< "$item"
+
+        # Skip non-initrd mounts in initrd
+        if in_initrd_host && ! [[ "$opts" =~ x-initrd.mount ]]; then
+            continue
+        fi
+
+        if [[ "$fstype" == swap ]]; then
+            unit="$(systemd-escape --suffix=swap --path "${what:?}")"
+            cat "$out_dir/$unit"
+
+            grep -qE "^What=$what$" "$out_dir/$unit"
+            if [[ "$opts" != defaults ]]; then
+                grep -qE "^Options=$opts$" "$out_dir/$unit"
+            fi
+
+            if [[ "$opts" =~ x-systemd.makefs ]]; then
+                service="$(systemd-escape --template=systemd-mkswap@.service --path "$what")"
+                test -e "$out_dir/$service"
+            fi
+
+            continue
+        fi
+
+        # If we're parsing host's fstab in initrd, prefix all mount targets
+        # with /sysroot
+        in_initrd_host && where="/sysroot${where:?}"
+        unit="$(systemd-escape --suffix=mount --path "${where:?}")"
+        cat "$out_dir/$unit"
+
+        # Check the general stuff
+        grep -qE "^What=$what$" "$out_dir/$unit"
+        grep -qE "^Where=$where$" "$out_dir/$unit"
+        if [[ -n "$fstype" ]] && [[ "$fstype" != auto ]]; then
+            grep -qE "^Type=$fstype$" "$out_dir/$unit"
+        fi
+        if [[ -n "$opts" ]] && [[ "$opts" != defaults ]]; then
+            # Some options are not propagated to the generated unit
+            if [[ "$where" == / ]]; then
+                filtered_options="$(opt_filter "$opts" "(noauto|nofail|x-systemd.(wanted-by=|required-by=|automount|device-timeout=))")"
+            else
+                filtered_options="$(opt_filter "$opts" "^x-systemd.device-timeout=")"
+            fi
+
+            if [[ "${filtered_options[*]}" != defaults ]]; then
+                grep -qE "^Options=.*$filtered_options.*$" "$out_dir/$unit"
+            fi
+        fi
+
+        if ! [[ "$opts" =~ (noauto|x-systemd.(wanted-by=|required-by=|automount)) ]]; then
+            # We don't create the Requires=/Wants= symlinks for noauto/automount mounts
+            # and for mounts that use x-systemd.wanted-by=/required-by=
+            if in_initrd_host; then
+                if [[ "$where" == / ]] || ! [[ "$opts" =~ nofail ]]; then
+                    link_eq "$out_dir/initrd-fs.target.requires/$unit" "$out_dir/$unit"
+                else
+                    link_eq "$out_dir/initrd-fs.target.wants/$unit" "$out_dir/$unit"
+                fi
+            elif [[ "$fstype" =~ $NETWORK_FS_RX || "$opts" =~ _netdev ]]; then
+                # Units with network filesystems should have a Requires= dependency
+                # on the remote-fs.target, unless they use nofail or are an nfs "bg"
+                # mounts, in which case the dependency is downgraded to Wants=
+                #
+                # The "bg" part is not true on RHEL 7, the "bg" change was introduced
+                # later, see 65e1dee7dcf1668c25c32f0238c935708dbffbcf
+                if [[ "$opts" =~ nofail ]]; then
+                    link_eq "$out_dir/remote-fs.target.wants/$unit" "$out_dir/$unit"
+                else
+                    link_eq "$out_dir/remote-fs.target.requires/$unit" "$out_dir/$unit"
+                fi
+            else
+                # Similarly, local filesystems should have a Requires= dependency on
+                # the local-fs.target, unless they use nofail, in which case the
+                # dependency is downgraded to Wants=. Rootfs is a special case,
+                # since we always ignore nofail there
+                if [[ "$where" == / ]] || ! [[ "$opts" =~ nofail ]]; then
+                    link_eq "$out_dir/local-fs.target.requires/$unit" "$out_dir/$unit"
+                else
+                    link_eq "$out_dir/local-fs.target.wants/$unit" "$out_dir/$unit"
+                fi
+            fi
+        fi
+
+        if [[ "${passno:=0}" -ne 0 ]]; then
+            # Generate systemd-fsck@.service dependencies, if applicable
+            if in_initrd && [[ "$where" == / || "$where" == /usr ]]; then
+                continue
+            fi
+
+            if [[ "$where" == / ]]; then
+                link_endswith "$out_dir/local-fs.target.wants/systemd-fsck-root.service" "/lib/systemd/system/systemd-fsck-root.service"
+            else
+                service="$(systemd-escape --template=systemd-fsck@.service --path "$what")"
+                grep -qE "^After=$service$" "$out_dir/$unit"
+                # On RHEL7 this uses RequiresOverridable=, which was later dropped
+                # completely and replaced with Wants=/Requires=
+                grep -qE "^RequiresOverridable=$service$" "$out_dir/$unit"
+            fi
+        fi
+
+        # Check various x-systemd options
+        #
+        # First, split them into an array to make splitting them even further
+        # easier
+        IFS="," read -ra split_options <<< "$opts"
+        # and process them one by one.
+        #
+        # Note: the "machinery" below might (and probably does) miss some
+        #       combinations of supported options, so tread carefully
+        for opt in "${split_options[@]}"; do
+            if [[ "$opt" =~ ^x-systemd.requires= ]]; then
+                service="$(opt_get_arg "$opt")"
+                grep -qE "^Requires=$service$" "$out_dir/$unit"
+                grep -qE "^After=$service$" "$out_dir/$unit"
+            elif [[ "$opt" =~ ^x-systemd.before= ]]; then
+                service="$(opt_get_arg "$opt")"
+                grep -qE "^Before=$service$" "$out_dir/$unit"
+            elif [[ "$opt" =~ ^x-systemd.after= ]]; then
+                service="$(opt_get_arg "$opt")"
+                grep -qE "^After=$service$" "$out_dir/$unit"
+            elif [[ "$opt" =~ ^x-systemd.wanted-by= ]]; then
+                service="$(opt_get_arg "$opt")"
+                if [[ "$where" == / ]]; then
+                    # This option is ignored for rootfs mounts
+                    (! link_eq "$out_dir/$service.wants/$unit" "../$unit")
+                else
+                    link_eq "$out_dir/$service.wants/$unit" "../$unit"
+                fi
+            elif [[ "$opt" =~ ^x-systemd.required-by= ]]; then
+                service="$(opt_get_arg "$opt")"
+                if [[ "$where" == / ]]; then
+                    # This option is ignored for rootfs mounts
+                    (! link_eq "$out_dir/$service.requires/$unit" "../$unit")
+                else
+                    link_eq "$out_dir/$service.requires/$unit" "../$unit"
+                fi
+            elif [[ "$opt" =~ ^x-systemd.requires-mounts-for= ]]; then
+                arg="$(opt_get_arg "$opt")"
+                grep -qE "^RequiresMountsFor=$arg$" "$out_dir/$unit"
+            elif [[ "$opt" == x-systemd.device-bound ]]; then
+                # This is implied for fstab mounts
+                :
+            elif [[ "$opt" == x-systemd.automount ]]; then
+                # The $unit should have an accompanying automount unit
+                supp="$(systemd-escape --suffix=automount --path "$where")"
+                if [[ "$where" == / ]]; then
+                    # This option is ignored for rootfs mounts
+                    test ! -e "$out_dir/$supp"
+                    (! link_eq "$out_dir/local-fs.target.requires/$supp" "$out_dir/$supp")
+                else
+                    test -e "$out_dir/$supp"
+                    link_eq "$out_dir/local-fs.target.requires/$supp" "$out_dir/$supp"
+                fi
+            elif [[ "$opt" =~ ^x-systemd.idle-timeout= ]]; then
+                # The timeout applies to the automount unit, not the original
+                # mount one
+                arg="$(opt_get_arg "$opt")"
+                supp="$(systemd-escape --suffix=automount --path "$where")"
+                grep -qE "^TimeoutIdleSec=$arg$" "$out_dir/$supp"
+            elif [[ "$opt" =~ ^x-systemd.device-timeout= ]]; then
+                arg="$(opt_get_arg "$opt")"
+                device="$(systemd-escape --suffix=device --path "$what")"
+                # In RHEL 7 this uses JobTimeoutSec=, since JobRunningTimeoutSec= was
+                # introduced later
+                grep -qE "^JobTimeoutSec=$arg$" "$out_dir/${device}.d/50-device-timeout.conf"
+            elif [[ "$opt" == x-systemd.makefs ]]; then
+                # In RHEL8 the unit is called systemd-mkfs@.service, see
+                # 804f8e1729e7663c75a88fcf0997539442b891d7
+                service="$(systemd-escape --template=systemd-mkfs@.service --path "$what")"
+                test -e "$out_dir/$service"
+                link_eq "$out_dir/${unit}.requires/$service" "../$service"
+            elif [[ "$opt" == x-systemd.rw-only ]]; then
+                grep -qE "^ReadWriteOnly=yes$" "$out_dir/$unit"
+            elif [[ "$opt" == x-systemd.growfs ]]; then
+                service="$(systemd-escape --template=systemd-growfs@.service --path "$where")"
+                # Another deviation from upstream, see 50072ccf1bfee8a53563a083a3a52b26f0d5678f
+                link_eq "$out_dir/${unit}.wants/$service" "../$service"
+            elif [[ "$opt" == bg ]] && [[ "$fstype" =~ ^(nfs|nfs4)$ ]]; then
+                # We "convert" nfs bg mounts to fg, so we can do the job-control
+                # ourselves
+                #
+                # Not true on RHEL 7, see 65e1dee7dcf1668c25c32f0238c935708dbffbcf
+                #grep -qE "^Options=.*\bx-systemd.mount-timeout=infinity\b" "$out_dir/$unit"
+                #grep -qE "^Options=.*\bfg\b.*" "$out_dir/$unit"
+                :
+            elif [[ "$opt" =~ ^x-systemd\. ]]; then
+                echo >&2 "Unhandled mount option: $opt"
+                exit 1
+            fi
+        done
+    done
+}
+
+: "fstab-generator: regular"
+printf "%s\n" "${FSTAB_GENERAL_ROOT[@]}" >"$FSTAB"
+cat "$FSTAB"
+SYSTEMD_FSTAB="$FSTAB" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+check_fstab_mount_units "$OUT_DIR" "${FSTAB_GENERAL_ROOT[@]}"
+
+# Skip the rest when running in a container, as it makes little sense to check
+# initrd-related stuff there and fstab-generator might have a bit strange
+# behavior during certain tests, like https://github.com/systemd/systemd/issues/27156
+if in_container; then
+    echo "Running in a container, skipping the rest of the fstab-generator tests..."
+    exit 0
+fi
+
+# In this mode we treat the entries as "regular" ones
+: "fstab-generator: initrd - initrd fstab"
+printf "%s\n" "${FSTAB_GENERAL[@]}" >"$FSTAB"
+cat "$FSTAB"
+SYSTEMD_IN_INITRD=1 SYSTEMD_FSTAB="$FSTAB" SYSTEMD_SYSROOT_FSTAB=/dev/null run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+SYSTEMD_IN_INITRD=1 SYSTEMD_FSTAB="$FSTAB" SYSTEMD_SYSROOT_FSTAB=/dev/null check_fstab_mount_units "$OUT_DIR" "${FSTAB_GENERAL[@]}"
+
+# In this mode we prefix the mount target with /sysroot and ignore all mounts
+# that don't have the x-initrd.mount flag
+: "fstab-generator: initrd - host fstab"
+printf "%s\n" "${FSTAB_GENERAL_ROOT[@]}" >"$FSTAB"
+cat "$FSTAB"
+SYSTEMD_IN_INITRD=1 SYSTEMD_FSTAB=/dev/null SYSTEMD_SYSROOT_FSTAB="$FSTAB" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+SYSTEMD_IN_INITRD=1 SYSTEMD_FSTAB=/dev/null SYSTEMD_SYSROOT_FSTAB="$FSTAB" check_fstab_mount_units "$OUT_DIR" "${FSTAB_GENERAL_ROOT[@]}"
+
+# Check the default stuff that we (almost) always create in initrd
+: "fstab-generator: initrd default"
+SYSTEMD_IN_INITRD=1 SYSTEMD_FSTAB=/dev/null SYSTEMD_SYSROOT_FSTAB=/dev/null run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+test -e "$OUT_DIR/normal/sysroot.mount"
+test -e "$OUT_DIR/normal/systemd-fsck-root.service"
+link_eq "$OUT_DIR/normal/initrd-root-fs.target.requires/sysroot.mount" "$OUT_DIR/normal/sysroot.mount"
+link_eq "$OUT_DIR/normal/initrd-root-fs.target.requires/sysroot.mount" "$OUT_DIR/normal/sysroot.mount"
+
+# systemd-sysroot-fstab-check is not in RHEL7
+
+: "fstab-generator: duplicate"
+printf "%s\n" "${FSTAB_DUPLICATE[@]}" >"$FSTAB"
+cat "$FSTAB"
+(! SYSTEMD_FSTAB="$FSTAB" run_and_list "$GENERATOR_BIN" "$OUT_DIR")
+
+: "fstab-generator: invalid"
+printf "%s\n" "${FSTAB_INVALID[@]}" >"$FSTAB"
+cat "$FSTAB"
+# Don't care about the exit code here
+SYSTEMD_FSTAB="$FSTAB" run_and_list "$GENERATOR_BIN" "$OUT_DIR" || :
+# No mounts should get created here
+[[ "$(find "$OUT_DIR" -name "*.mount" | wc -l)" -eq 0 ]]
+
+: "fstab-generator: kernel args - fstab=0"
+printf "%s\n" "${FSTAB_MINIMAL[@]}" >"$FSTAB"
+SYSTEMD_FSTAB="$FSTAB" SYSTEMD_PROC_CMDLINE="fstab=0" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+(! SYSTEMD_FSTAB="$FSTAB" check_fstab_mount_units "$OUT_DIR" "${FSTAB_MINIMAL[@]}")
+SYSTEMD_IN_INITRD=1 SYSTEMD_FSTAB="$FSTAB" SYSTEMD_PROC_CMDLINE="fstab=0" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+(! SYSTEMD_IN_INITRD=1 SYSTEMD_FSTAB="$FSTAB" check_fstab_mount_units "$OUT_DIR" "${FSTAB_MINIMAL[@]}")
+
+: "fstab-generator: kernel args - rd.fstab=0"
+printf "%s\n" "${FSTAB_MINIMAL[@]}" >"$FSTAB"
+SYSTEMD_FSTAB="$FSTAB" SYSTEMD_PROC_CMDLINE="rd.fstab=0" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+SYSTEMD_FSTAB="$FSTAB" check_fstab_mount_units "$OUT_DIR" "${FSTAB_MINIMAL[@]}"
+SYSTEMD_IN_INITRD=1 SYSTEMD_FSTAB="$FSTAB" SYSTEMD_PROC_CMDLINE="rd.fstab=0" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+(! SYSTEMD_IN_INITRD=1 SYSTEMD_FSTAB="$FSTAB" check_fstab_mount_units "$OUT_DIR" "${FSTAB_MINIMAL[@]}")
+
+# systemd.swap kernel cmdline arguments is not supported on RHEL7, see
+# 567a5307601728c618546c584f63307283fa8def
+
+# Possible TODO
+#   - combine the rootfs & usrfs arguments and mix them with fstab entries
+#   - systemd.volatile=
+: "fstab-generator: kernel args - root= + rootfstype= + rootflags="
+# shellcheck disable=SC2034
+EXPECTED_FSTAB=(
+    "/dev/disk/by-label/rootfs  /    ext4    noexec,ro   0 1"
+)
+CMDLINE="root=LABEL=rootfs rootfstype=ext4 rootflags=noexec"
+SYSTEMD_IN_INITRD=1 SYSTEMD_FSTAB=/dev/null SYSTEMD_SYSROOT_FSTAB=/dev/null SYSTEMD_PROC_CMDLINE="$CMDLINE" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+# The /proc/cmdline here is a dummy value to tell the in_initrd_host() function
+# we're parsing host's fstab, but it's all on the kernel cmdline instead
+SYSTEMD_IN_INITRD=1 SYSTEMD_SYSROOT_FSTAB=/proc/cmdline check_fstab_mount_units "$OUT_DIR" "${EXPECTED_FSTAB[@]}"
+
+# This is a very basic sanity test that involves manual checks, since adding it
+# to the check_fstab_mount_units() function would make it way too complex
+# (yet another possible TODO)
+: "fstab-generator: kernel args - mount.usr= + mount.usrfstype= + mount.usrflags="
+CMDLINE="mount.usr=UUID=be780f43-8803-4a76-9732-02ceda6e9808 mount.usrfstype=ext4 mount.usrflags=noexec,nodev"
+SYSTEMD_IN_INITRD=1 SYSTEMD_FSTAB=/dev/null SYSTEMD_SYSROOT_FSTAB=/dev/null SYSTEMD_PROC_CMDLINE="$CMDLINE" run_and_list "$GENERATOR_BIN" "$OUT_DIR"
+cat "$OUT_DIR/normal/sysroot-usr.mount"
+# We don't do the /sysusr/usr/ -> /sysroot/usr/ dance on RHEL7, see
+# 29a24ab28e9790680348b1ffab653a321fa49a67
+grep -qE "^What=/dev/disk/by-uuid/be780f43-8803-4a76-9732-02ceda6e9808$" "$OUT_DIR/normal/sysroot-usr.mount"
+grep -qE "^Where=/sysroot/usr$" "$OUT_DIR/normal/sysroot-usr.mount"
+grep -qE "^Type=ext4$" "$OUT_DIR/normal/sysroot-usr.mount"
+grep -qE "^Options=noexec,nodev,ro$" "$OUT_DIR/normal/sysroot-usr.mount"
+link_eq "$OUT_DIR/normal/initrd-fs.target.requires/sysroot-usr.mount" "$OUT_DIR/normal/sysroot-usr.mount"

--- a/test/TEST-81-GENERATORS/testsuite.sh
+++ b/test/TEST-81-GENERATORS/testsuite.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -eux
+set -o pipefail
+
+: >/failed
+
+for script in "${0%.sh}".*.sh; do
+    echo "Running $script"
+    "./$script"
+done
+
+touch /testok
+rm /failed

--- a/test/test-functions
+++ b/test/test-functions
@@ -12,7 +12,7 @@ if ! ROOTLIBDIR=$(pkg-config --variable=systemdutildir systemd); then
     ROOTLIBDIR=/usr/lib/systemd
 fi
 
-BASICTOOLS="test sh bash setsid loadkeys setfont login sulogin gzip sleep echo mount umount cryptsetup date dmsetup modprobe chmod chown ln sed cmp tee"
+BASICTOOLS="test sh bash setsid loadkeys setfont login sulogin gzip sleep echo mount umount cryptsetup date dmsetup modprobe chmod chown ln sed cmp tee dirname readlink mktemp fsck.ext4 fsck.ext3 fsck.ext2"
 DEBUGTOOLS="df free ls stty cat ps ln ip route dmesg dhclient mkdir cp ping dhclient strace less grep id tty touch du sort hostname"
 
 function find_qemu_bin() {


### PR DESCRIPTION
Backport of three fstab-generator commits:

commit 634735b56b82bdde3c67193ba7b470bab80fdcbd ("fstab-generator: Chase symlinks where possible (#6293)" -- reverted in PR#149)
commit 98eda38aed6a10c4f6d6ad0cac6e5361e87de52b ("call chase_symlinks without the /sysroot prefix (#6411)" -- fixing the issue that required the revert)
commit f1a2c7584dcf9ba7d8f11291ae3fa2c5c361bdfa ("fstab-generator: downgrade message when we can't canonicalize fstab entries (#8281)" -- adjust log message priority)


Resolves: RHEL-17394

<!-- issue-commentator = {"comment-id":"1893808659"} -->